### PR TITLE
Add depth of field and bloom to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ You must copy the following files into the `client` directory of this repository
 - `extra/Mesa-7.2/OPENGL32.DLL` -> `client/OPENGL32.DLL`
 - `extra/Mesa-7.2/OSMESA32.DLL` -> `client/OSMESA32.DLL`
 
+# Bloom and Depth of Field #
+Just like the [mid-2007 client](https://github.com/CloneTrooper1019/Roblox-2007-Client#enabling-bloom-and-depth-of-field-effects), you can enable depth of field and bloom. It's still disabled, so you will need to hex-edit the executable with a program such as HxD. To enable either one of these, change the following offsets from 00 to 01.
+- Bloom: `F2401`
+- Depth of Field: `F240E`
+
+![Depth of field and bloom in a hex editor](https://user-images.githubusercontent.com/62524115/111388579-8a0bdf80-867d-11eb-9bf0-f36fafc4ca1a.png)
+
+
 ## IMPORTANT NOTES ##
 
 - When these DLL files are active, the rendering speed will slow to a crawl depending on the resolution of the game window.


### PR DESCRIPTION
I feel like this should be added like the mid-2007 repo. It works perfectly on the client.
![U65TykXLwJ](https://user-images.githubusercontent.com/62524115/111388796-ee2ea380-867d-11eb-80aa-f33b0984e7f4.png)
![kJeHI1HbLD](https://user-images.githubusercontent.com/62524115/111388809-f25ac100-867d-11eb-8733-b52473d50701.png)

